### PR TITLE
Resume type usage from parse5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 import { parse } from "parse5";
+import {
+  Document,
+  Element,
+} from "../node_modules/parse5/dist/tree-adapters/default.js";
 import { validateImageAttributes } from "./validators/image.js";
 import { readFileSync, accessSync, constants } from "fs";
 
@@ -19,19 +23,19 @@ export function runValidation(files: string[]) {
 }
 
 function validateFileContents(fileContents: string) {
-  const rootNode = parse(fileContents, {
+  const rootNode: Document = parse(fileContents, {
     sourceCodeLocationInfo: true,
   });
 
-  validateElements(rootNode.childNodes[1]);
+  validateElements(rootNode.childNodes[1] as Element);
 }
 
-function validateElements(node: any): void {
+function validateElements(node: Element): void {
   const childCount: number = node?.childNodes?.length ?? 0;
 
   if (childCount == 0) return;
 
-  node.childNodes.forEach((e: any) => {
+  (node.childNodes as Element[]).forEach((e) => {
     validateImageAttributes(e);
     validateElements(e);
   });

--- a/src/validators/image.ts
+++ b/src/validators/image.ts
@@ -1,10 +1,11 @@
 import { TAG_NAMES } from "../enums/tags.js";
+import { Element } from "../../node_modules/parse5/dist/tree-adapters/default.js";
 
 const enum IMAGE_ATTRIBUTES {
   alt = "alt",
 }
 
-export function validateImageAttributes(node: any) {
+export function validateImageAttributes(node: Element) {
   if (node.tagName !== TAG_NAMES.IMG) return;
 
   if (!node.attrs.find((e: any) => e.name === IMAGE_ATTRIBUTES.alt) ?? true) {


### PR DESCRIPTION
Resume type usage which requires relative imports from `parse5`